### PR TITLE
Add FileService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.4'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-aws-autoconfigure
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws-autoconfigure', version: '2.2.1.RELEASE'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.oracle.database.jdbc:ojdbc8'

--- a/src/main/java/com/neconico/neconico/dto/file/FileResultInfoDto.java
+++ b/src/main/java/com/neconico/neconico/dto/file/FileResultInfoDto.java
@@ -1,9 +1,7 @@
 package com.neconico.neconico.dto.file;
 
 import lombok.Getter;
-import lombok.Setter;
 
-@Setter
 @Getter
 public class FileResultInfoDto {
     private String fileUrls;

--- a/src/main/java/com/neconico/neconico/dto/file/FileResultInfoDto.java
+++ b/src/main/java/com/neconico/neconico/dto/file/FileResultInfoDto.java
@@ -1,14 +1,16 @@
-package com.neconico.neconico.immutable;
+package com.neconico.neconico.dto.file;
 
 import lombok.Getter;
+import lombok.Setter;
 
+@Setter
 @Getter
-public class FileResultInfo {
+public class FileResultInfoDto {
     private String fileUrls;
 
     private String fileNames;
 
-    public FileResultInfo(String fileUrls, String fileNames) {
+    public FileResultInfoDto(String fileUrls, String fileNames) {
         this.fileUrls = fileUrls;
         this.fileNames = fileNames;
     }

--- a/src/main/java/com/neconico/neconico/file/policy/FilePolicy.java
+++ b/src/main/java/com/neconico/neconico/file/policy/FilePolicy.java
@@ -1,0 +1,18 @@
+package com.neconico.neconico.file.policy;
+
+import lombok.Getter;
+
+@Getter
+public enum FilePolicy {
+    STORE("store", 1),
+    ADVERTISEMENT("adver", 1),
+    ITEM("item", 3);
+
+    private String dirName;
+    private int fileCount;
+
+    FilePolicy(String dirName, int fileCount) {
+        this.dirName = dirName;
+        this.fileCount = fileCount;
+    }
+}

--- a/src/main/java/com/neconico/neconico/file/process/FileProcess.java
+++ b/src/main/java/com/neconico/neconico/file/process/FileProcess.java
@@ -9,6 +9,6 @@ public interface FileProcess {
 
     FileResultInfo uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException;
 
-    boolean deleteFiles(String fileNames) throws IllegalArgumentException;
+    boolean canDeleteFiles(String fileNames) throws IllegalArgumentException;
 
 }

--- a/src/main/java/com/neconico/neconico/file/process/FileProcess.java
+++ b/src/main/java/com/neconico/neconico/file/process/FileProcess.java
@@ -1,13 +1,13 @@
 package com.neconico.neconico.file.process;
 
-import com.neconico.neconico.immutable.FileResultInfo;
+import com.neconico.neconico.dto.file.FileResultInfoDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
 public interface FileProcess {
 
-    FileResultInfo uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException;
+    FileResultInfoDto uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException;
 
     boolean canDeleteFiles(String fileNames) throws IllegalArgumentException;
 

--- a/src/main/java/com/neconico/neconico/file/process/FileProcess.java
+++ b/src/main/java/com/neconico/neconico/file/process/FileProcess.java
@@ -1,0 +1,14 @@
+package com.neconico.neconico.file.process;
+
+import com.neconico.neconico.immutable.FileResultInfo;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface FileProcess {
+
+    FileResultInfo uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException;
+
+    boolean deleteFiles(String fileNames) throws IllegalArgumentException;
+
+}

--- a/src/main/java/com/neconico/neconico/file/process/LocalFileProcess.java
+++ b/src/main/java/com/neconico/neconico/file/process/LocalFileProcess.java
@@ -1,0 +1,118 @@
+package com.neconico.neconico.file.process;
+
+import com.neconico.neconico.file.policy.FilePolicy;
+import com.neconico.neconico.immutable.FileResultInfo;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class LocalFileProcess implements FileProcess {
+
+    private static final String LOCAL_DIR = "C:/Temp/";
+
+    private String dirName;
+
+    private int fileCount;
+
+    private StringBuffer fileUrls = new StringBuffer();
+
+    private StringBuffer fileNames = new StringBuffer();
+
+    public LocalFileProcess(FilePolicy filePolicy) {
+        dirName = filePolicy.getDirName();
+        fileCount = filePolicy.getFileCount();
+    }
+
+    @Override
+    public FileResultInfo uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException {
+        if(files.length > fileCount) {
+            throw new IllegalArgumentException("There are more files than should be received");
+        }
+
+        for (MultipartFile file : files) {
+            createDir();
+
+            File dest = createDest(file);
+
+            file.transferTo(dest);
+
+            makeFileNamesAndURLs(dest);
+
+        }
+
+        return makeFileResultInfo();
+    }
+
+    private void createDir() {
+        File file = new File(LOCAL_DIR + dirName + "/");
+        if (!file.exists()) {
+            file.mkdir();
+        }
+    }
+
+    private File createDest(MultipartFile file) {
+        return new File(LOCAL_DIR + dirName + "/" + convertUniqueName(file.getOriginalFilename()));
+    }
+
+    private String convertUniqueName(String originalFileName) {
+        return UUID.randomUUID() + originalFileName;
+    }
+
+    private void makeFileNamesAndURLs(File dest) throws IOException {
+        fileNames.append(dest + ":");
+        fileUrls.append(dest.toURI().toURL() + ":");
+    }
+
+    private FileResultInfo makeFileResultInfo() {
+        String fileUrls = this.fileUrls.deleteCharAt(this.fileUrls.length() - 1).toString();
+
+        String fileNames = this.fileNames.deleteCharAt(this.fileNames.length() - 1).toString();
+
+        return new FileResultInfo(fileUrls, fileNames);
+    }
+
+    @Override
+    public boolean deleteFiles(String fileNames) throws IllegalArgumentException {
+        if(fileNames == null || fileNames.length() == 0) {
+            throw new IllegalArgumentException("Entered the wrong path");
+        }
+
+        String[] originalFileNames = fileNames.split(":");
+
+        return deleteOriginFiles(originalFileNames);
+
+    }
+
+    private boolean deleteOriginFiles(String[] originalFileNames) {
+        List<Boolean> deleteResults = new ArrayList<>();
+
+        for(String originalFileName : originalFileNames) {
+            File originalFile = new File(originalFileName);
+
+            if(originalFile.exists()) {
+                deleteResults.add(originalFile.delete());
+            }
+
+            deleteResults.add(false);
+        }
+
+        return countResult(deleteResults);
+
+    }
+
+    private boolean countResult(List<Boolean> deleteResults) {
+        int resultCount = 0;
+
+        for(boolean result : deleteResults) {
+            if(result) {
+                resultCount++;
+            }
+        }
+
+        return resultCount > 0 ;
+    }
+}

--- a/src/main/java/com/neconico/neconico/file/process/LocalFileProcess.java
+++ b/src/main/java/com/neconico/neconico/file/process/LocalFileProcess.java
@@ -1,7 +1,7 @@
 package com.neconico.neconico.file.process;
 
 import com.neconico.neconico.file.policy.FilePolicy;
-import com.neconico.neconico.immutable.FileResultInfo;
+import com.neconico.neconico.dto.file.FileResultInfoDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -28,7 +28,7 @@ public class LocalFileProcess implements FileProcess {
     }
 
     @Override
-    public FileResultInfo uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException {
+    public FileResultInfoDto uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException {
         if(files.length > fileCount) {
             throw new IllegalArgumentException("There are more files than should be received");
         }
@@ -79,12 +79,12 @@ public class LocalFileProcess implements FileProcess {
         fileUrls.append(dest.toURI().toURL() + ":");
     }
 
-    private FileResultInfo createFileResultInfo() {
+    private FileResultInfoDto createFileResultInfo() {
         String fileUrls = this.fileUrls.deleteCharAt(this.fileUrls.length() - 1).toString();
 
         String fileNames = this.fileNames.deleteCharAt(this.fileNames.length() - 1).toString();
 
-        return new FileResultInfo(fileUrls, fileNames);
+        return new FileResultInfoDto(fileUrls, fileNames);
     }
 
     private boolean deleteOriginFiles(String[] originalFileNames) {

--- a/src/main/java/com/neconico/neconico/file/process/LocalFileProcess.java
+++ b/src/main/java/com/neconico/neconico/file/process/LocalFileProcess.java
@@ -40,11 +40,23 @@ public class LocalFileProcess implements FileProcess {
 
             file.transferTo(dest);
 
-            makeFileNamesAndURLs(dest);
+            insertFileNamesAndURLs(dest);
 
         }
 
-        return makeFileResultInfo();
+        return createFileResultInfo();
+    }
+
+    @Override
+    public boolean canDeleteFiles(String fileNames) throws IllegalArgumentException {
+        if(fileNames == null || fileNames.length() == 0) {
+            throw new IllegalArgumentException("Entered the wrong path");
+        }
+
+        String[] originalFileNames = fileNames.split(":");
+
+        return deleteOriginFiles(originalFileNames);
+
     }
 
     private void createDir() {
@@ -62,29 +74,17 @@ public class LocalFileProcess implements FileProcess {
         return UUID.randomUUID() + originalFileName;
     }
 
-    private void makeFileNamesAndURLs(File dest) throws IOException {
+    private void insertFileNamesAndURLs(File dest) throws IOException {
         fileNames.append(dest + ":");
         fileUrls.append(dest.toURI().toURL() + ":");
     }
 
-    private FileResultInfo makeFileResultInfo() {
+    private FileResultInfo createFileResultInfo() {
         String fileUrls = this.fileUrls.deleteCharAt(this.fileUrls.length() - 1).toString();
 
         String fileNames = this.fileNames.deleteCharAt(this.fileNames.length() - 1).toString();
 
         return new FileResultInfo(fileUrls, fileNames);
-    }
-
-    @Override
-    public boolean deleteFiles(String fileNames) throws IllegalArgumentException {
-        if(fileNames == null || fileNames.length() == 0) {
-            throw new IllegalArgumentException("Entered the wrong path");
-        }
-
-        String[] originalFileNames = fileNames.split(":");
-
-        return deleteOriginFiles(originalFileNames);
-
     }
 
     private boolean deleteOriginFiles(String[] originalFileNames) {
@@ -100,11 +100,11 @@ public class LocalFileProcess implements FileProcess {
             deleteResults.add(false);
         }
 
-        return countResult(deleteResults);
+        return isCountResult(deleteResults);
 
     }
 
-    private boolean countResult(List<Boolean> deleteResults) {
+    private boolean isCountResult(List<Boolean> deleteResults) {
         int resultCount = 0;
 
         for(boolean result : deleteResults) {

--- a/src/main/java/com/neconico/neconico/file/process/S3FileProcess.java
+++ b/src/main/java/com/neconico/neconico/file/process/S3FileProcess.java
@@ -3,7 +3,7 @@ package com.neconico.neconico.file.process;
 import com.neconico.neconico.file.policy.FilePolicy;
 import com.neconico.neconico.file.s3provider.S3Deleter;
 import com.neconico.neconico.file.s3provider.S3Uploader;
-import com.neconico.neconico.immutable.FileResultInfo;
+import com.neconico.neconico.dto.file.FileResultInfoDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ public class S3FileProcess implements FileProcess{
     }
 
     @Override
-    public FileResultInfo uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException {
+    public FileResultInfoDto uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException {
         if(files.length > fileCount) {
             throw new IllegalArgumentException("There are more files than should be received");
         }
@@ -48,7 +48,7 @@ public class S3FileProcess implements FileProcess{
 
         deleteLastColon();
 
-        return new FileResultInfo(fileUrls.toString(), fileNames.toString());
+        return new FileResultInfoDto(fileUrls.toString(), fileNames.toString());
     }
 
     @Override

--- a/src/main/java/com/neconico/neconico/file/process/S3FileProcess.java
+++ b/src/main/java/com/neconico/neconico/file/process/S3FileProcess.java
@@ -1,0 +1,94 @@
+package com.neconico.neconico.file.process;
+
+import com.neconico.neconico.file.policy.FilePolicy;
+import com.neconico.neconico.file.s3provider.S3Deleter;
+import com.neconico.neconico.file.s3provider.S3Uploader;
+import com.neconico.neconico.immutable.FileResultInfo;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class S3FileProcess implements FileProcess{
+
+    private S3Uploader s3Uploader;
+
+    private S3Deleter s3Deleter;
+
+    private String dirName;
+
+    private int fileCount;
+
+    private StringBuffer fileNames = new StringBuffer();
+
+    private StringBuffer fileUrls = new StringBuffer();
+
+    public S3FileProcess(FilePolicy filePolicy) throws IllegalArgumentException {
+        this.dirName = filePolicy.getDirName();
+        this.fileCount = filePolicy.getFileCount();
+    }
+
+    public void setUploaderAndDeleter(S3Uploader uploader, S3Deleter deleter) {
+        s3Uploader = uploader;
+        s3Deleter = deleter;
+    }
+
+    @Override
+    public FileResultInfo uploadFile(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException {
+        if(files.length > fileCount) {
+            throw new IllegalArgumentException("There are more files than should be received");
+        }
+
+        for(MultipartFile file : files) {
+            fileUrls.append(s3Uploader.upload(file, convertUniqueFileName(file), dirName) + ":");
+        }
+
+        deleteLastColon();
+
+        return new FileResultInfo(fileUrls.toString(), fileNames.toString());
+    }
+
+    private String convertUniqueFileName(MultipartFile file) {
+        String fileName = UUID.randomUUID() + file.getOriginalFilename();
+
+        fileNames.append(fileName + ":");
+
+        return fileName;
+    }
+
+    private void deleteLastColon() {
+        fileNames.deleteCharAt(fileNames.length() - 1);
+        fileUrls.deleteCharAt(fileUrls.length() - 1);
+    }
+
+    @Override
+    public boolean deleteFiles(String fileName) throws IllegalArgumentException {
+        if(fileName == null || fileName.length() == 0) {
+            throw new IllegalArgumentException("Entered the wrong path");
+        }
+
+        String[] fileOriginNames = fileName.split(":");
+
+        if(fileOriginNames.length > 1) {
+            return deleteFiles(fileOriginNames);
+        }
+
+        s3Deleter.delete(dirName, fileOriginNames[0]);
+        return true;
+    }
+
+    private boolean deleteFiles(String[] fileOriginNames) {
+        s3Deleter.deletes(dirName, convertList(fileOriginNames));
+        return true;
+    }
+
+    private List<String> convertList(String[] fileOriginNames) {
+        return Arrays.stream(fileOriginNames)
+                .map(f -> dirName + "/" + f)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/neconico/neconico/file/process/S3FileProcess.java
+++ b/src/main/java/com/neconico/neconico/file/process/S3FileProcess.java
@@ -51,21 +51,8 @@ public class S3FileProcess implements FileProcess{
         return new FileResultInfo(fileUrls.toString(), fileNames.toString());
     }
 
-    private String convertUniqueFileName(MultipartFile file) {
-        String fileName = UUID.randomUUID() + file.getOriginalFilename();
-
-        fileNames.append(fileName + ":");
-
-        return fileName;
-    }
-
-    private void deleteLastColon() {
-        fileNames.deleteCharAt(fileNames.length() - 1);
-        fileUrls.deleteCharAt(fileUrls.length() - 1);
-    }
-
     @Override
-    public boolean deleteFiles(String fileName) throws IllegalArgumentException {
+    public boolean canDeleteFiles(String fileName) throws IllegalArgumentException {
         if(fileName == null || fileName.length() == 0) {
             throw new IllegalArgumentException("Entered the wrong path");
         }
@@ -78,6 +65,19 @@ public class S3FileProcess implements FileProcess{
 
         s3Deleter.delete(dirName, fileOriginNames[0]);
         return true;
+    }
+
+    private String convertUniqueFileName(MultipartFile file) {
+        String fileName = UUID.randomUUID() + file.getOriginalFilename();
+
+        fileNames.append(fileName + ":");
+
+        return fileName;
+    }
+
+    private void deleteLastColon() {
+        fileNames.deleteCharAt(fileNames.length() - 1);
+        fileUrls.deleteCharAt(fileUrls.length() - 1);
     }
 
     private boolean deleteFiles(String[] fileOriginNames) {

--- a/src/main/java/com/neconico/neconico/file/s3provider/S3Deleter.java
+++ b/src/main/java/com/neconico/neconico/file/s3provider/S3Deleter.java
@@ -1,0 +1,94 @@
+package com.neconico.neconico.file.s3provider;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.amazonaws.services.s3.model.DeleteObjectsRequest.*;
+
+@Slf4j
+@Component
+public class S3Deleter {
+    private AmazonS3 s3Client;
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @PostConstruct
+    public void setS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
+
+        s3Client = AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(this.region)
+                .build();
+    }
+
+    public void delete(String dirName, String fileName) {
+
+        String bucketFolder =  bucket + "/" + dirName;
+
+        try {
+            s3Client.deleteObject(new DeleteObjectRequest(bucketFolder, fileName));
+            log.info("파일이 버킷에서 삭제되었습니다.");
+
+        }catch (AmazonServiceException e) {
+            e.printStackTrace();
+
+        }catch (SdkClientException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void deletes(String dirName, List<String> fileNames) {
+        String bucketFolder =  bucket + "/" + dirName;
+
+        try {
+            DeleteObjectsResult deleteObjectsResult = s3Client.deleteObjects(createRequest(bucketFolder, fileNames));
+
+            int successfulDeletes = deleteObjectsResult.getDeletedObjects().size();
+
+            log.info("{}개 파일이 버킷에서 삭제되었습니다.", successfulDeletes);
+
+        } catch(AmazonServiceException e) {
+            e.printStackTrace();
+
+        }catch (SdkClientException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    private DeleteObjectsRequest createRequest(String bucketFolder, List<String> fileNames) {
+
+        List<KeyVersion> keys = fileNames.stream()
+                .map(KeyVersion::new)
+                .collect(Collectors.toList());
+
+        return new DeleteObjectsRequest(bucketFolder)
+                .withKeys(keys);
+    }
+}

--- a/src/main/java/com/neconico/neconico/file/s3provider/S3Uploader.java
+++ b/src/main/java/com/neconico/neconico/file/s3provider/S3Uploader.java
@@ -1,0 +1,98 @@
+package com.neconico.neconico.file.s3provider;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.PostConstruct;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class S3Uploader {
+    private AmazonS3 s3Client;
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @PostConstruct
+    public void setS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
+
+        s3Client = AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(this.region)
+                .build();
+    }
+
+    public String upload(MultipartFile multipartFile, String fileName, String dirName) throws IOException {
+        File uploadFile = convert(multipartFile, fileName)
+                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File로 전환이 실패했습니다."));
+
+        return upload(uploadFile, dirName);
+    }
+
+    private Optional<File> convert(MultipartFile file, String fileName) throws IOException {
+        File convertFile = new File(fileName);
+
+        if(convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+
+        return Optional.empty();
+    }
+
+    private String upload(File uploadFile, String dirName) {
+        String fileName = uploadFile.getName();
+
+        String bucketFolder = bucket + "/" + dirName;
+
+        String uploadImageUrl = putS3(uploadFile, fileName, bucketFolder);
+
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile, String fileName, String bucketFolder) {
+        s3Client.putObject(
+                new PutObjectRequest(bucketFolder, fileName, uploadFile)
+                        .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        return s3Client.getUrl(bucketFolder, fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if(targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+            log.info("파일업로드에 성공하였습니다.");
+            return;
+        }
+
+        log.info("파일이 삭제되지 못했습니다.");
+        log.info("파일업로드에 성공하였습니다.");
+
+    }
+}

--- a/src/main/java/com/neconico/neconico/immutable/FileResultInfo.java
+++ b/src/main/java/com/neconico/neconico/immutable/FileResultInfo.java
@@ -1,0 +1,15 @@
+package com.neconico.neconico.immutable;
+
+import lombok.Getter;
+
+@Getter
+public class FileResultInfo {
+    private String fileUrls;
+
+    private String fileNames;
+
+    public FileResultInfo(String fileUrls, String fileNames) {
+        this.fileUrls = fileUrls;
+        this.fileNames = fileNames;
+    }
+}

--- a/src/main/java/com/neconico/neconico/service/file/FileService.java
+++ b/src/main/java/com/neconico/neconico/service/file/FileService.java
@@ -1,0 +1,17 @@
+package com.neconico.neconico.service.file;
+
+import com.neconico.neconico.file.process.FileProcess;
+import com.neconico.neconico.immutable.FileResultInfo;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface FileService {
+
+    void setFileProcess(FileProcess fileProcess);
+
+    FileResultInfo uploadFiles(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException;
+
+    boolean deleteFiles(String fileNames) throws IllegalArgumentException;
+
+}

--- a/src/main/java/com/neconico/neconico/service/file/FileService.java
+++ b/src/main/java/com/neconico/neconico/service/file/FileService.java
@@ -1,7 +1,7 @@
 package com.neconico.neconico.service.file;
 
 import com.neconico.neconico.file.process.FileProcess;
-import com.neconico.neconico.immutable.FileResultInfo;
+import com.neconico.neconico.dto.file.FileResultInfoDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -10,7 +10,7 @@ public interface FileService {
 
     void setFileProcess(FileProcess fileProcess);
 
-    FileResultInfo uploadFiles(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException;
+    FileResultInfoDto uploadFiles(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException;
 
     boolean canDeleteFiles(String fileNames) throws IllegalArgumentException;
 

--- a/src/main/java/com/neconico/neconico/service/file/FileService.java
+++ b/src/main/java/com/neconico/neconico/service/file/FileService.java
@@ -12,6 +12,6 @@ public interface FileService {
 
     FileResultInfo uploadFiles(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException;
 
-    boolean deleteFiles(String fileNames) throws IllegalArgumentException;
+    boolean canDeleteFiles(String fileNames) throws IllegalArgumentException;
 
 }

--- a/src/main/java/com/neconico/neconico/service/file/FileServiceImpl.java
+++ b/src/main/java/com/neconico/neconico/service/file/FileServiceImpl.java
@@ -1,0 +1,43 @@
+package com.neconico.neconico.service.file;
+
+import com.neconico.neconico.file.process.FileProcess;
+import com.neconico.neconico.file.process.S3FileProcess;
+import com.neconico.neconico.file.s3provider.S3Deleter;
+import com.neconico.neconico.file.s3provider.S3Uploader;
+import com.neconico.neconico.immutable.FileResultInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class FileServiceImpl implements FileService{
+
+    private final S3Uploader s3Uploader;
+
+    private final S3Deleter s3Deleter;
+
+    private FileProcess fileProcess;
+
+    @Override
+    public void setFileProcess(FileProcess fileProcess) {
+
+        if(fileProcess instanceof S3FileProcess) {
+            ((S3FileProcess) fileProcess).setUploaderAndDeleter(s3Uploader, s3Deleter);
+        }
+        this.fileProcess = fileProcess;
+    }
+
+    @Override
+    public FileResultInfo uploadFiles(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException {
+        return fileProcess.uploadFile(files);
+    }
+
+    @Override
+    public boolean deleteFiles(String fileNames) throws IllegalArgumentException {
+        return fileProcess.deleteFiles(fileNames);
+    }
+
+}

--- a/src/main/java/com/neconico/neconico/service/file/FileServiceImpl.java
+++ b/src/main/java/com/neconico/neconico/service/file/FileServiceImpl.java
@@ -36,8 +36,8 @@ public class FileServiceImpl implements FileService{
     }
 
     @Override
-    public boolean deleteFiles(String fileNames) throws IllegalArgumentException {
-        return fileProcess.deleteFiles(fileNames);
+    public boolean canDeleteFiles(String fileNames) throws IllegalArgumentException {
+        return fileProcess.canDeleteFiles(fileNames);
     }
 
 }

--- a/src/main/java/com/neconico/neconico/service/file/FileServiceImpl.java
+++ b/src/main/java/com/neconico/neconico/service/file/FileServiceImpl.java
@@ -4,7 +4,7 @@ import com.neconico.neconico.file.process.FileProcess;
 import com.neconico.neconico.file.process.S3FileProcess;
 import com.neconico.neconico.file.s3provider.S3Deleter;
 import com.neconico.neconico.file.s3provider.S3Uploader;
-import com.neconico.neconico.immutable.FileResultInfo;
+import com.neconico.neconico.dto.file.FileResultInfoDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -31,7 +31,7 @@ public class FileServiceImpl implements FileService{
     }
 
     @Override
-    public FileResultInfo uploadFiles(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException {
+    public FileResultInfoDto uploadFiles(MultipartFile... files) throws IOException, IllegalStateException, IllegalArgumentException {
         return fileProcess.uploadFile(files);
     }
 

--- a/src/test/java/com/neconico/neconico/file/policy/FilePolicyTest.java
+++ b/src/test/java/com/neconico/neconico/file/policy/FilePolicyTest.java
@@ -1,0 +1,92 @@
+package com.neconico.neconico.file.policy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilePolicyTest {
+
+    @Test
+    @DisplayName("STORE 정책에 따른 파일개수")
+    void number_of_files_according_to_store_policy() {
+        //given
+        FilePolicy store = FilePolicy.STORE;
+
+        //when
+        int fileCount = store.getFileCount();
+
+        //then
+        assertThat(fileCount).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("STORE 정책에 따른 디렉토리 이름")
+    void directory_name_according_to_store_policy() {
+        //given
+        FilePolicy store = FilePolicy.STORE;
+
+        //when
+        String dirName = store.getDirName();
+
+        //then
+        assertThat(dirName).isEqualTo("store");
+
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT 정책에 따른 파일개수")
+    void number_of_files_according_to_advertisement_policy() {
+        //given
+        FilePolicy advertisement = FilePolicy.ADVERTISEMENT;
+
+        //when
+        int fileCount = advertisement.getFileCount();
+
+        //then
+        assertThat(fileCount).isEqualTo(1);
+
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT 정책에 따른 디렉토리 이름")
+    void  directory_name_according_to_advertisement_policy() {
+        //given
+        FilePolicy advertisement = FilePolicy.ADVERTISEMENT;
+
+        //when
+        String dirName = advertisement.getDirName();
+
+        //then
+        assertThat(dirName).isEqualTo("adver");
+
+    }
+
+    @Test
+    @DisplayName("ITEM 정책에 따른 파일개수")
+    void number_of_files_according_to_item_policy() {
+        //given
+        FilePolicy item = FilePolicy.ITEM;
+
+        //when
+        int fileCount = item.getFileCount();
+
+        //then
+        assertThat(fileCount).isEqualTo(3);
+
+    }
+
+    @Test
+    @DisplayName("ITEM 정책에 따른 디렉토리 이름")
+    void directory_name_according_to_item_policy() {
+        //given
+        FilePolicy item = FilePolicy.ITEM;
+
+        //when
+        String dirName = item.getDirName();
+
+        //then
+        assertThat(dirName).isEqualTo("item");
+
+    }
+}

--- a/src/test/java/com/neconico/neconico/file/process/LocalFileProcessTest.java
+++ b/src/test/java/com/neconico/neconico/file/process/LocalFileProcessTest.java
@@ -1,0 +1,315 @@
+package com.neconico.neconico.file.process;
+
+import com.neconico.neconico.file.policy.FilePolicy;
+import com.neconico.neconico.immutable.FileResultInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.*;
+
+class LocalFileProcessTest {
+
+    private FileProcess localFileProcess;
+
+    private MockMultipartFile[] files;
+
+    @BeforeEach
+    void getMockMultipartFiles() {
+        files = createMockMultipartFiles();
+    }
+
+    private MockMultipartFile[] createMockMultipartFiles() {
+
+        MockMultipartFile[] files = new MockMultipartFile[4];
+
+        for (int i = 0; i < 4; i++) {
+            StringBuffer fileName = new StringBuffer("test" + i + 1 + ".jpg");
+
+            files[i] = new MockMultipartFile(
+                    "content",
+                    fileName.toString(),
+                    "multipart/mixed",
+                    "hello word".getBytes(StandardCharsets.UTF_8));
+        }
+
+        return files;
+    }
+
+    /**
+     * 파일정책에 따른 파일저장
+     * 파일정책에 따른 파일삭제
+     */
+    @Test
+    @DisplayName("STORE정책에 따른 파일 저장")
+    void upload_according_to_store_file_policy() throws Exception {
+        //given
+        this.localFileProcess = new LocalFileProcess(FilePolicy.STORE);
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+    }
+
+    @Test
+    @DisplayName("ITEM정책에 따른 1개 파일 저장")
+    void upload_one_file_according_to_item_file_policy() throws Exception {
+        //given
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ITEM);
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+
+    }
+
+    @Test
+    @DisplayName("ITEM정책에 따른 3개 파일 저장")
+    void upload_three_file_according_to_item_file_policy() throws Exception {
+        //given
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ITEM);
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 3);
+
+        //when
+        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT정책에 따른 파일 저장")
+    void upload_according_to_advertisement_file_policy() throws Exception {
+        //given
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ADVERTISEMENT);
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+    }
+
+    @Test
+    @DisplayName("STORE정책에 따른 파일 삭제")
+    void delete_according_to_store_file_policy() throws Exception {
+        //given
+        this.localFileProcess = new LocalFileProcess(FilePolicy.STORE);
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+
+        boolean result = localFileProcess.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("ITEM정책에 따른 1개 파일 삭제")
+    void delete_one_file_according_to_item_file_policy() throws Exception {
+        //given
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ITEM);
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+
+        boolean result = localFileProcess.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("ITEM정책에 따른 3개 파일 삭제")
+    void delete_three_file_according_to_item_file_policy() throws Exception {
+        //given
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ITEM);
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 3);
+
+        //when
+        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+
+        boolean result = localFileProcess.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT정책에 따른 파일 삭제")
+    void delete_according_to_advertisement_file_policy() throws Exception {
+        //given
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ADVERTISEMENT);
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+
+        boolean result = localFileProcess.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    /**
+     * 파일저장 예외처리
+     */
+    @Test
+    @DisplayName("STORE 정책에 1개 보다 많은 파일이 들어갔을 경우 예외처리")
+    void exception_handling_more_than_one_file_entered_in_store_strategy() {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 2);
+
+
+        //when
+        this.localFileProcess = new LocalFileProcess(FilePolicy.STORE);
+
+        //then
+        assertThatThrownBy(() -> this.localFileProcess.uploadFile(files))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("There are more files than should be received");
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT 정책에 1개보다 많은 파일이 들어갔을 경우 예외처리")
+    void exception_handling_more_than_one_file_entered_in_advertisement_strategy() {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 2);
+
+        //when
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ADVERTISEMENT);
+
+        //then
+        assertThatThrownBy(() -> this.localFileProcess.uploadFile(files))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("There are more files than should be received");
+    }
+
+    @Test
+    @DisplayName("ITEM 정책에 3개보다 많은 파일이 들어갔을 경우 예외처리")
+    void exception_handling_more_than_one_file_entered_in_item_strategy() {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 4);
+
+        //when
+        this.localFileProcess = new LocalFileProcess(FilePolicy.STORE);
+
+        //then
+        assertThatThrownBy(() -> this.localFileProcess.uploadFile(files))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("There are more files than should be received");
+    }
+
+
+    @Test
+    @DisplayName("ADVERTISEMENT 정책에 따른 파일삭제 경로에 빈값을 입력하였을 경우 예외처리")
+    void exception_handling_incorrect_file_entered_in_advertisement_strategy_deleteMethod() {
+        //given
+        String fileNames= "";
+
+        //when
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ADVERTISEMENT);
+
+        //then
+        assertThatThrownBy(() -> localFileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT 전략에 따른 파일삭제 경로에 null값을 입력하였을 경우 예외처리")
+    void exception_handling_null_entered_in_advertisement_strategy_deleteMethod() {
+        //given
+        String fileNames = null;
+
+        //when
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ADVERTISEMENT);
+
+        //then
+        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+
+    @Test
+    @DisplayName("ITEM 전략에 따른 파일삭제 경로를 잘못 입력하였을 경우 예외처리")
+    void exception_handling_incorrect_file_entered_in_item_strategy_deleteMethod() {
+        //given
+        String fileNames = "";
+
+        //when
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ITEM);
+
+        //then
+        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+    @Test
+    @DisplayName("ITEM 전략에 따른 파일삭제 경로에 null값을 입력하였을 경우 예외처리")
+    void exception_handling_null_entered_in_item_strategy_deleteMethod() {
+        //given
+        String fileNames = null;
+
+        //when
+        this.localFileProcess = new LocalFileProcess(FilePolicy.ITEM);
+
+        //then
+        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+    @Test
+    @DisplayName("STORE 전략에 따른 파일삭제 경로에 빈값을 입력하였을 경우 예외처리")
+    void exception_handling_incorrect_file_entered_in_store_strategy_deleteMethod() {
+        //given
+        String fileNames = "";
+
+        //when
+        this.localFileProcess = new LocalFileProcess(FilePolicy.STORE);
+
+        //then
+        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+    @Test
+    @DisplayName("STORE 전략에 따른 파일삭제 경로에 null값을 입력하였을 경우 예외처리")
+    void exception_handling_null_entered_in_store_strategy_deleteMethod() {
+        //given
+        String fileNames = null;
+
+        //when
+        this.localFileProcess = new LocalFileProcess(FilePolicy.STORE);
+
+        //then
+        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+}

--- a/src/test/java/com/neconico/neconico/file/process/LocalFileProcessTest.java
+++ b/src/test/java/com/neconico/neconico/file/process/LocalFileProcessTest.java
@@ -1,7 +1,7 @@
 package com.neconico.neconico.file.process;
 
 import com.neconico.neconico.file.policy.FilePolicy;
-import com.neconico.neconico.immutable.FileResultInfo;
+import com.neconico.neconico.dto.file.FileResultInfoDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,10 +53,10 @@ class LocalFileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = localFileProcess.uploadFile(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+        assertThat(fileResultInfoDto.getFileNames()).contains(files[0].getOriginalFilename());
     }
 
     @Test
@@ -68,10 +68,10 @@ class LocalFileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = localFileProcess.uploadFile(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+        assertThat(fileResultInfoDto.getFileNames()).contains(files[0].getOriginalFilename());
 
     }
 
@@ -84,10 +84,10 @@ class LocalFileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 3);
 
         //when
-        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = localFileProcess.uploadFile(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+        assertThat(fileResultInfoDto.getFileNames()).contains(files[0].getOriginalFilename());
     }
 
     @Test
@@ -98,10 +98,10 @@ class LocalFileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = localFileProcess.uploadFile(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+        assertThat(fileResultInfoDto.getFileNames()).contains(files[0].getOriginalFilename());
     }
 
     @Test
@@ -113,9 +113,9 @@ class LocalFileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = localFileProcess.uploadFile(files);
 
-        boolean result = localFileProcess.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = localFileProcess.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -130,9 +130,9 @@ class LocalFileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = localFileProcess.uploadFile(files);
 
-        boolean result = localFileProcess.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = localFileProcess.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -147,9 +147,9 @@ class LocalFileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 3);
 
         //when
-        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = localFileProcess.uploadFile(files);
 
-        boolean result = localFileProcess.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = localFileProcess.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -164,9 +164,9 @@ class LocalFileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = localFileProcess.uploadFile(files);
 
-        boolean result = localFileProcess.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = localFileProcess.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();

--- a/src/test/java/com/neconico/neconico/file/process/LocalFileProcessTest.java
+++ b/src/test/java/com/neconico/neconico/file/process/LocalFileProcessTest.java
@@ -115,7 +115,7 @@ class LocalFileProcessTest {
         //when
         FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
 
-        boolean result = localFileProcess.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = localFileProcess.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -132,7 +132,7 @@ class LocalFileProcessTest {
         //when
         FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
 
-        boolean result = localFileProcess.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = localFileProcess.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -149,7 +149,7 @@ class LocalFileProcessTest {
         //when
         FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
 
-        boolean result = localFileProcess.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = localFileProcess.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -166,7 +166,7 @@ class LocalFileProcessTest {
         //when
         FileResultInfo fileResultInfo = localFileProcess.uploadFile(files);
 
-        boolean result = localFileProcess.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = localFileProcess.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -232,7 +232,7 @@ class LocalFileProcessTest {
         this.localFileProcess = new LocalFileProcess(FilePolicy.ADVERTISEMENT);
 
         //then
-        assertThatThrownBy(() -> localFileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> localFileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -247,7 +247,7 @@ class LocalFileProcessTest {
         this.localFileProcess = new LocalFileProcess(FilePolicy.ADVERTISEMENT);
 
         //then
-        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> this.localFileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -263,7 +263,7 @@ class LocalFileProcessTest {
         this.localFileProcess = new LocalFileProcess(FilePolicy.ITEM);
 
         //then
-        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> this.localFileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -278,7 +278,7 @@ class LocalFileProcessTest {
         this.localFileProcess = new LocalFileProcess(FilePolicy.ITEM);
 
         //then
-        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> this.localFileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -293,7 +293,7 @@ class LocalFileProcessTest {
         this.localFileProcess = new LocalFileProcess(FilePolicy.STORE);
 
         //then
-        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> this.localFileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -308,7 +308,7 @@ class LocalFileProcessTest {
         this.localFileProcess = new LocalFileProcess(FilePolicy.STORE);
 
         //then
-        assertThatThrownBy(() -> this.localFileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> this.localFileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }

--- a/src/test/java/com/neconico/neconico/file/process/S3FileProcessTest.java
+++ b/src/test/java/com/neconico/neconico/file/process/S3FileProcessTest.java
@@ -1,0 +1,383 @@
+package com.neconico.neconico.file.process;
+
+import com.neconico.neconico.file.policy.FilePolicy;
+import com.neconico.neconico.file.s3provider.S3Deleter;
+import com.neconico.neconico.file.s3provider.S3Uploader;
+import com.neconico.neconico.immutable.FileResultInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class S3FileProcessTest {
+
+    @Autowired
+    private S3Uploader s3Uploader;
+
+    @Autowired
+    private S3Deleter s3Deleter;
+
+    private FileProcess fileProcess;
+
+    private MockMultipartFile[] files;
+
+    @BeforeEach
+    void getMockMultipartFiles() {
+        files = createMockMultipartFiles();
+    }
+
+    private MockMultipartFile[] createMockMultipartFiles() {
+
+        MockMultipartFile[] files = new MockMultipartFile[4];
+
+        for (int i = 0; i < 4; i++) {
+            StringBuffer fileName = new StringBuffer("test" + i + 1 + ".jpg");
+
+            files[i] = new MockMultipartFile(
+                    "content",
+                    fileName.toString(),
+                    "multipart/mixed",
+                    "hello word".getBytes(StandardCharsets.UTF_8));
+        }
+
+        return files;
+    }
+
+    /**
+     * 파일정책에 따른 파일저장
+     * 파일정책에 따른 파일삭제
+     */
+    @Test
+    @DisplayName("STORE 정책에 따른 파일 저장")
+    void upload_according_to_store_file_policy() throws Exception {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.STORE);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+    }
+
+    @Test
+    @DisplayName("ITEM 정책에 따른 1개 파일 저장")
+    void upload_one_file_according_to_item_file_policy() throws Exception {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ITEM);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+
+    }
+
+    @Test
+    @DisplayName("ITEM 정책에 따른 3개 파일 저장")
+    void upload_three_file_according_to_item_file_policy() throws Exception {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ITEM);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 3);
+
+        //when
+        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames())
+                .contains(
+                        files[0].getOriginalFilename(),
+                        files[1].getOriginalFilename(),
+                        files[2].getOriginalFilename()
+                );
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT 정책에 따른 파일 저장")
+    void upload_according_to_advertisement_file_policy() throws Exception {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ADVERTISEMENT);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+    }
+
+    @Test
+    @DisplayName("STORE 정책에 따른 파일 삭제")
+    void delete_according_to_store_file_policy() throws Exception {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.STORE);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+
+        boolean result = fileProcess.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("ITEM 정책에 따른 1개 파일 삭제")
+    void delete_one_file_according_to_item_file_policy() throws Exception {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ITEM);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+
+        boolean result = fileProcess.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("ITEM 정책에 따른 3개 파일 삭제")
+    void delete_three_file_according_to_item_file_policy() throws Exception {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ITEM);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 3);
+
+        //when
+        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+
+        boolean result = fileProcess.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT 정책에 따른 파일 삭제")
+    void delete_according_to_advertisement_file_policy() throws Exception {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ADVERTISEMENT);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
+
+        //when
+        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+
+        boolean result = fileProcess.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    /**
+     * 파일저장 예외처리
+     */
+    @Test
+    @DisplayName("STORE 정책에 1개 보다 많은 파일이 들어갔을 경우 예외처리")
+    void exception_handling_more_than_one_file_entered_in_store_policy() {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 2);
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.STORE);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        //then
+        assertThatThrownBy(() -> fileProcess.uploadFile(files))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("There are more files than should be received");
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT 정책에 1개보다 많은 파일이 들어갔을 경우 예외처리")
+    void exception_handling_more_than_one_file_entered_in_advertisement_policy() {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 2);
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ADVERTISEMENT);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        //then
+        assertThatThrownBy(() -> fileProcess.uploadFile(files))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("There are more files than should be received");
+    }
+
+    @Test
+    @DisplayName("ITEM 정책에 3개보다 많은 파일이 들어갔을 경우 예외처리")
+    void exception_handling_more_than_one_file_entered_in_item_policy() {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, 4);
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ITEM);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        //then
+        assertThatThrownBy(() -> fileProcess.uploadFile(files))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("There are more files than should be received");
+    }
+
+
+    @Test
+    @DisplayName("ADVERTISEMENT 정책에 따른 파일삭제 경로에 빈값을 입력하였을 경우 예외처리")
+    void exception_handling_incorrect_file_entered_in_advertisement_policy_deleteMethod() {
+        //given
+        String fileNames= "";
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ADVERTISEMENT);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        //then
+        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+    @Test
+    @DisplayName("ADVERTISEMENT 정책에 따른 파일삭제 경로에 null값을 입력하였을 경우 예외처리")
+    void exception_handling_null_entered_in_advertisement_policy_deleteMethod() {
+        //given
+        String fileNames = null;
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ADVERTISEMENT);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        //then
+        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+
+    @Test
+    @DisplayName("ITEM 정책에 따른 파일삭제 경로를 잘못 입력하였을 경우 예외처리")
+    void exception_handling_incorrect_file_entered_in_item_policy_deleteMethod() {
+        //given
+        String fileNames = "";
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ITEM);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        //then
+        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+    @Test
+    @DisplayName("ITEM 정책에 따른 파일삭제 경로에 null값을 입력하였을 경우 예외처리")
+    void exception_handling_null_entered_in_item_policy_deleteMethod() {
+        //given
+        String fileNames = null;
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.ITEM);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        //then
+        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+    @Test
+    @DisplayName("STORE 정책에 따른 파일삭제 경로에 빈값을 입력하였을 경우 예외처리")
+    void exception_handling_incorrect_file_entered_in_store_policy_deleteMethod() {
+        //given
+        String fileNames = "";
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.STORE);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        //then
+        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+
+    @Test
+    @DisplayName("STORE 정책에 따른 파일삭제 경로에 null값을 입력하였을 경우 예외처리")
+    void exception_handling_null_entered_in_store_policy_deleteMethod() {
+        //given
+        String fileNames = null;
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.STORE);
+        s3FileProcess.setUploaderAndDeleter(s3Uploader, s3Deleter);
+
+        this.fileProcess = s3FileProcess;
+
+        //then
+        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+    }
+}

--- a/src/test/java/com/neconico/neconico/file/process/S3FileProcessTest.java
+++ b/src/test/java/com/neconico/neconico/file/process/S3FileProcessTest.java
@@ -148,7 +148,7 @@ class S3FileProcessTest {
         //when
         FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
 
-        boolean result = fileProcess.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileProcess.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -168,7 +168,7 @@ class S3FileProcessTest {
         //when
         FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
 
-        boolean result = fileProcess.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileProcess.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -188,7 +188,7 @@ class S3FileProcessTest {
         //when
         FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
 
-        boolean result = fileProcess.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileProcess.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -208,7 +208,7 @@ class S3FileProcessTest {
         //when
         FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
 
-        boolean result = fileProcess.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileProcess.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -285,7 +285,7 @@ class S3FileProcessTest {
         this.fileProcess = s3FileProcess;
 
         //then
-        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -303,7 +303,7 @@ class S3FileProcessTest {
         this.fileProcess = s3FileProcess;
 
         //then
-        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -322,7 +322,7 @@ class S3FileProcessTest {
         this.fileProcess = s3FileProcess;
 
         //then
-        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -340,7 +340,7 @@ class S3FileProcessTest {
         this.fileProcess = s3FileProcess;
 
         //then
-        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -358,7 +358,7 @@ class S3FileProcessTest {
         this.fileProcess = s3FileProcess;
 
         //then
-        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }
@@ -376,7 +376,7 @@ class S3FileProcessTest {
         this.fileProcess = s3FileProcess;
 
         //then
-        assertThatThrownBy(() -> fileProcess.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileProcess.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
     }

--- a/src/test/java/com/neconico/neconico/file/process/S3FileProcessTest.java
+++ b/src/test/java/com/neconico/neconico/file/process/S3FileProcessTest.java
@@ -3,7 +3,7 @@ package com.neconico.neconico.file.process;
 import com.neconico.neconico.file.policy.FilePolicy;
 import com.neconico.neconico.file.s3provider.S3Deleter;
 import com.neconico.neconico.file.s3provider.S3Uploader;
-import com.neconico.neconico.immutable.FileResultInfo;
+import com.neconico.neconico.dto.file.FileResultInfoDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -68,10 +68,10 @@ class S3FileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = fileProcess.uploadFile(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+        assertThat(fileResultInfoDto.getFileNames()).contains(files[0].getOriginalFilename());
     }
 
     @Test
@@ -86,10 +86,10 @@ class S3FileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = fileProcess.uploadFile(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+        assertThat(fileResultInfoDto.getFileNames()).contains(files[0].getOriginalFilename());
 
     }
 
@@ -105,10 +105,10 @@ class S3FileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 3);
 
         //when
-        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = fileProcess.uploadFile(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames())
+        assertThat(fileResultInfoDto.getFileNames())
                 .contains(
                         files[0].getOriginalFilename(),
                         files[1].getOriginalFilename(),
@@ -128,10 +128,10 @@ class S3FileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = fileProcess.uploadFile(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames()).contains(files[0].getOriginalFilename());
+        assertThat(fileResultInfoDto.getFileNames()).contains(files[0].getOriginalFilename());
     }
 
     @Test
@@ -146,9 +146,9 @@ class S3FileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = fileProcess.uploadFile(files);
 
-        boolean result = fileProcess.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileProcess.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -166,9 +166,9 @@ class S3FileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = fileProcess.uploadFile(files);
 
-        boolean result = fileProcess.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileProcess.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -186,9 +186,9 @@ class S3FileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 3);
 
         //when
-        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = fileProcess.uploadFile(files);
 
-        boolean result = fileProcess.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileProcess.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -206,9 +206,9 @@ class S3FileProcessTest {
         MockMultipartFile[] files = Arrays.copyOf(this.files, 1);
 
         //when
-        FileResultInfo fileResultInfo = fileProcess.uploadFile(files);
+        FileResultInfoDto fileResultInfoDto = fileProcess.uploadFile(files);
 
-        boolean result = fileProcess.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileProcess.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();

--- a/src/test/java/com/neconico/neconico/service/file/FileServiceImplTest.java
+++ b/src/test/java/com/neconico/neconico/service/file/FileServiceImplTest.java
@@ -1,0 +1,301 @@
+package com.neconico.neconico.service.file;
+
+import com.neconico.neconico.file.policy.FilePolicy;
+import com.neconico.neconico.file.process.LocalFileProcess;
+import com.neconico.neconico.file.process.S3FileProcess;
+import com.neconico.neconico.immutable.FileResultInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class FileServiceImplTest {
+
+    @Autowired
+    private FileServiceImpl fileService;
+
+    private MockMultipartFile[] files;
+
+    @BeforeEach
+    void getMockMultipartFiles() {
+        files = createMockMultipartFiles();
+    }
+
+    private MockMultipartFile[] createMockMultipartFiles() {
+
+        MockMultipartFile[] files = new MockMultipartFile[4];
+
+        for (int i = 0; i < 4; i++) {
+            StringBuffer fileName = new StringBuffer("test" + i + 1 + ".jpg");
+
+            files[i] = new MockMultipartFile(
+                    "content",
+                    fileName.toString(),
+                    "multipart/mixed",
+                    "hello word".getBytes(StandardCharsets.UTF_8));
+        }
+
+        return files;
+    }
+
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}일때")
+    @DisplayName("Local프로세스 전략을 넣을시 해당 서비스 필드값에 LocalProcess가 잘 참조가 되었는지 확인")
+    @EnumSource(FilePolicy.class)
+    void confirm_fieldvalue_localprocess_according_to_strategy(FilePolicy filePolicy) {
+        //given
+        LocalFileProcess localFileProcess = new LocalFileProcess(filePolicy);
+
+        //when
+        fileService.setFileProcess(localFileProcess);
+
+        //then
+        assertThat(fileService)
+                .extracting("fileProcess")
+                .isInstanceOf(LocalFileProcess.class);
+
+    }
+
+
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}일때")
+    @DisplayName("S3프로세스 전략을 넣을시 해당 서비스 필드값에 S3Process가 잘 참조가 되었는지 확인")
+    @EnumSource(FilePolicy.class)
+    void confirm_fieldvalue_s3process_according_to_strategy(FilePolicy filePolicy) {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(filePolicy);
+
+        //when
+        fileService.setFileProcess(s3FileProcess);
+
+        //then
+        assertThat(fileService)
+                .extracting("fileProcess")
+                .isInstanceOf(S3FileProcess.class);
+
+    }
+
+    /**
+     * Local,S3 process일때 파일저장
+     */
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}이고 파일개수 {1}개 일때")
+    @DisplayName("로컬프로세스일때 정책들에 따른 파일저장")
+    @CsvSource({"'STORE', 1", "'ITEM', 3", "'ADVERTISEMENT', 1"})
+    void upload_file_when_using_local_process(String filePolicy, int fileCount) throws Exception {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, fileCount);
+
+        LocalFileProcess localFileProcess = new LocalFileProcess(FilePolicy.valueOf(filePolicy));
+
+        //when
+        fileService.setFileProcess(localFileProcess);
+
+        FileResultInfo fileResultInfo = fileService.uploadFiles(files);
+
+        String[] fileNames = createFileName(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames()).contains(fileNames);
+
+    }
+
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}이고 파일개수 {1}개 일때")
+    @DisplayName("S3프로세스일때 정책들에 따른 파일저장")
+    @CsvSource({"'STORE', 1", "'ITEM', 3", "'ADVERTISEMENT', 1"})
+    void upload_file_when_using_s3_process(String filePolicy, int fileCount) throws Exception {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, fileCount);
+
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.valueOf(filePolicy));
+
+        //when
+        fileService.setFileProcess(s3FileProcess);
+
+        FileResultInfo fileResultInfo = fileService.uploadFiles(files);
+
+        String[] fileNames = createFileName(files);
+
+        //then
+        assertThat(fileResultInfo.getFileNames()).contains(fileNames);
+
+    }
+
+    private String[] createFileName(MultipartFile[] files) {
+        String[] fileNames = new String[files.length];
+
+        for(int i=0; i<files.length; i++) {
+            fileNames[i] = files[i].getOriginalFilename();
+        }
+        return fileNames;
+    }
+
+    /**
+     * Local,S3 process일때 파일삭제
+     */
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}이고 파일개수 {1}개 일때")
+    @DisplayName("로컬프로세스일때 정책들에 따른 파일저장")
+    @CsvSource({"'STORE', 1", "'ITEM', 3", "'ADVERTISEMENT', 1"})
+    void delete_file_when_using_local_process(String filePolicy, int fileCount) throws Exception {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, fileCount);
+
+        LocalFileProcess localFileProcess = new LocalFileProcess(FilePolicy.valueOf(filePolicy));
+
+        //when
+        fileService.setFileProcess(localFileProcess);
+
+        FileResultInfo fileResultInfo = fileService.uploadFiles(files);
+
+        boolean result = fileService.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}이고 파일개수 {1}개 일때")
+    @DisplayName("S3프로세스일때 정책들에 따른 파일저장")
+    @CsvSource({"'STORE', 1", "'ITEM', 3", "'ADVERTISEMENT', 1"})
+    void delete_file_when_using_s3_process(String filePolicy, int fileCount) throws Exception {
+        //given
+        MockMultipartFile[] files = Arrays.copyOf(this.files, fileCount);
+
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.valueOf(filePolicy));
+
+        //when
+        fileService.setFileProcess(s3FileProcess);
+
+        FileResultInfo fileResultInfo = fileService.uploadFiles(files);
+
+        boolean result = fileService.deleteFiles(fileResultInfo.getFileNames());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    /**
+     * Local,S3 process일때 파일저장 예외처리
+     */
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}이고 파일개수 {1}개 일때")
+    @DisplayName("로컬프로세스일때 정책들에 따른 파일저장시 해당 정책에 맞지않은 파일개수가 들어갔을때 예외처리")
+    @CsvSource({"'STORE', 2", "'ITEM', 4", "'ADVERTISEMENT', 2"})
+    void exception_handling_when_the_number_of_files_that_do_not_match_the_policy_is_entered_on_local(String filePolicy, int fileCount) {
+        //given
+        LocalFileProcess localFileProcess = new LocalFileProcess(FilePolicy.valueOf(filePolicy));
+        fileService.setFileProcess(localFileProcess);
+
+        //when
+        MockMultipartFile[] files = Arrays.copyOf(this.files, fileCount);
+
+        //then
+        assertThatThrownBy(() -> fileService.uploadFiles(files))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("There are more files than should be received");
+    }
+
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}이고 파일개수 {1}개 일때")
+    @DisplayName("S3프로세스일때 정책들에 따른 파일저장시 해당 정책에 맞지않은 파일개수가 들어갔을때 예외처리")
+    @CsvSource({"'STORE', 2", "'ITEM', 4", "'ADVERTISEMENT', 2"})
+    void exception_handling_when_the_number_of_files_that_do_not_match_the_policy_is_entered_on_s3(String filePolicy, int fileCount) {
+        //given
+        S3FileProcess s3FileProcess = new S3FileProcess(FilePolicy.valueOf(filePolicy));
+        fileService.setFileProcess(s3FileProcess);
+
+        //when
+        MockMultipartFile[] files = Arrays.copyOf(this.files, fileCount);
+
+        //then
+        assertThatThrownBy(() -> fileService.uploadFiles(files))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("There are more files than should be received");
+    }
+
+    /**
+     * Local,S3 process일때 파일삭제 예외처리
+     */
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}일때")
+    @DisplayName("정책에따라 파일이름에 null이 로컬에 입력 된 경우 예외 처리")
+    @EnumSource(FilePolicy.class)
+    void exception_handling_when_null_is_entered_local_in_the_file_name_according_to_policy(FilePolicy filePolicy) {
+        //given
+        String fileNames = null;
+
+        //when
+        LocalFileProcess localFileProcess = new LocalFileProcess(filePolicy);
+
+        fileService.setFileProcess(localFileProcess);
+
+        //then
+        assertThatThrownBy(() -> fileService.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+
+    }
+
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}일때")
+    @DisplayName("정책에따라 파일이름에 null이 s3에 입력 된 경우 예외 처리")
+    @EnumSource(FilePolicy.class)
+    void exception_handling_when_null_is_entered_s3_in_the_file_name_according_to_policy(FilePolicy filePolicy) {
+        //given
+        String fileNames = null;
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(filePolicy);
+
+        fileService.setFileProcess(s3FileProcess);
+
+        //then
+        assertThatThrownBy(() -> fileService.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+
+    }
+
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}일때")
+    @DisplayName("정책에따라 파일이름에 공백이 로컬에 입력 된 경우 예외 처리")
+    @EnumSource(FilePolicy.class)
+    void exception_handling_when_spaces_is_entered_local_in_the_file_name_according_to_policy(FilePolicy filePolicy) {
+        //given
+        String fileNames = "";
+
+        //when
+        LocalFileProcess localFileProcess = new LocalFileProcess(filePolicy);
+
+        fileService.setFileProcess(localFileProcess);
+
+        //then
+        assertThatThrownBy(() -> fileService.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+
+    }
+
+    @ParameterizedTest(name = "{index} -> FilePolicy가 {0}일때")
+    @DisplayName("정책에따라 파일이름에 공백이 s3에 입력 된 경우 예외 처리")
+    @EnumSource(FilePolicy.class)
+    void exception_handling_when_spaces_is_entered_s3_in_the_file_name_according_to_policy(FilePolicy filePolicy) {
+        //given
+        String fileNames = null;
+
+        //when
+        S3FileProcess s3FileProcess = new S3FileProcess(filePolicy);
+
+        fileService.setFileProcess(s3FileProcess);
+
+        //then
+        assertThatThrownBy(() -> fileService.deleteFiles(fileNames))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Entered the wrong path");
+
+    }
+}

--- a/src/test/java/com/neconico/neconico/service/file/FileServiceImplTest.java
+++ b/src/test/java/com/neconico/neconico/service/file/FileServiceImplTest.java
@@ -3,7 +3,7 @@ package com.neconico.neconico.service.file;
 import com.neconico.neconico.file.policy.FilePolicy;
 import com.neconico.neconico.file.process.LocalFileProcess;
 import com.neconico.neconico.file.process.S3FileProcess;
-import com.neconico.neconico.immutable.FileResultInfo;
+import com.neconico.neconico.dto.file.FileResultInfoDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -100,12 +100,12 @@ class FileServiceImplTest {
         //when
         fileService.setFileProcess(localFileProcess);
 
-        FileResultInfo fileResultInfo = fileService.uploadFiles(files);
+        FileResultInfoDto fileResultInfoDto = fileService.uploadFiles(files);
 
         String[] fileNames = createFileName(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames()).contains(fileNames);
+        assertThat(fileResultInfoDto.getFileNames()).contains(fileNames);
 
     }
 
@@ -121,12 +121,12 @@ class FileServiceImplTest {
         //when
         fileService.setFileProcess(s3FileProcess);
 
-        FileResultInfo fileResultInfo = fileService.uploadFiles(files);
+        FileResultInfoDto fileResultInfoDto = fileService.uploadFiles(files);
 
         String[] fileNames = createFileName(files);
 
         //then
-        assertThat(fileResultInfo.getFileNames()).contains(fileNames);
+        assertThat(fileResultInfoDto.getFileNames()).contains(fileNames);
 
     }
 
@@ -154,9 +154,9 @@ class FileServiceImplTest {
         //when
         fileService.setFileProcess(localFileProcess);
 
-        FileResultInfo fileResultInfo = fileService.uploadFiles(files);
+        FileResultInfoDto fileResultInfoDto = fileService.uploadFiles(files);
 
-        boolean result = fileService.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileService.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -174,9 +174,9 @@ class FileServiceImplTest {
         //when
         fileService.setFileProcess(s3FileProcess);
 
-        FileResultInfo fileResultInfo = fileService.uploadFiles(files);
+        FileResultInfoDto fileResultInfoDto = fileService.uploadFiles(files);
 
-        boolean result = fileService.canDeleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileService.canDeleteFiles(fileResultInfoDto.getFileNames());
 
         //then
         assertThat(result).isTrue();

--- a/src/test/java/com/neconico/neconico/service/file/FileServiceImplTest.java
+++ b/src/test/java/com/neconico/neconico/service/file/FileServiceImplTest.java
@@ -6,7 +6,6 @@ import com.neconico.neconico.file.process.S3FileProcess;
 import com.neconico.neconico.immutable.FileResultInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -157,7 +156,7 @@ class FileServiceImplTest {
 
         FileResultInfo fileResultInfo = fileService.uploadFiles(files);
 
-        boolean result = fileService.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileService.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -177,7 +176,7 @@ class FileServiceImplTest {
 
         FileResultInfo fileResultInfo = fileService.uploadFiles(files);
 
-        boolean result = fileService.deleteFiles(fileResultInfo.getFileNames());
+        boolean result = fileService.canDeleteFiles(fileResultInfo.getFileNames());
 
         //then
         assertThat(result).isTrue();
@@ -236,7 +235,7 @@ class FileServiceImplTest {
         fileService.setFileProcess(localFileProcess);
 
         //then
-        assertThatThrownBy(() -> fileService.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileService.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
 
@@ -255,7 +254,7 @@ class FileServiceImplTest {
         fileService.setFileProcess(s3FileProcess);
 
         //then
-        assertThatThrownBy(() -> fileService.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileService.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
 
@@ -274,7 +273,7 @@ class FileServiceImplTest {
         fileService.setFileProcess(localFileProcess);
 
         //then
-        assertThatThrownBy(() -> fileService.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileService.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
 
@@ -293,7 +292,7 @@ class FileServiceImplTest {
         fileService.setFileProcess(s3FileProcess);
 
         //then
-        assertThatThrownBy(() -> fileService.deleteFiles(fileNames))
+        assertThatThrownBy(() -> fileService.canDeleteFiles(fileNames))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Entered the wrong path");
 


### PR DESCRIPTION
FileService 개발

* FileProcess 
   두개의 구현체가 있다.
   각각의 프로세스는 정책(FilePolicy)에 따라서 다르게 작동한다.

 - LocalFileProcess
   로컬에 파일을 업로드, 삭제를 위해 프로세스를 제공하는 객체
 
 - S3FileProcess 
   AWS S3 버킷에 파일을 업로드, 삭제를 위해 프로세스를 제공하는 객체
   S3Uploader에게 upload를 위임한다
   S3Deleter에게 delete를 위임한다.

* S3Provider 
 - S3Uploader
   AWS S3에 직접 업로드에 관여하는 객체
 - S3Delteer
   AWS S3에 직접 삭제에 관여하는 객체

* FilePolicy 
 - STORE
 - ITEM
 - ADVERTISEMENT
   각각의 파일정책정보가 담겨있는 ENUM클래스

* FileService
 - 전략패턴을 사용하여 각각의 프로세스를 선택할 수 있다.

* FileResultInfoDto
 - 반환한 파일URL과 파일명에 대한 신뢰도를 주기위해 setter을 없애주었다.